### PR TITLE
Fix navigation targets and layout wrappers on Education and Work pages

### DIFF
--- a/Education.html
+++ b/Education.html
@@ -1,12 +1,11 @@
 <!DOCTYPE HTML>
-
 <html>
 	<head>
-		<title>Projects</title>
+		<title>Education</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="assets/css/main.css" />
-        <link rel="stylesheet" href="assets/css/education.css" />
+		<link rel="stylesheet" href="assets/css/education.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
 	<body class="is-preload">
@@ -16,7 +15,7 @@
 
 				<!-- Header -->
 					<header id="header">
-						<a href="generic.html" class="logo">Education</a>
+						<a href="Education.html" class="logo">Education</a>
 					</header>
 
 				<!-- Nav -->
@@ -25,29 +24,31 @@
 							<li><a href="index.html">About Me</a></li>
 							<li><a href="generic.html">Projects</a></li>
 							<li><a href="work.html">Work experience</a></li>
-                            <li class="active"><a href="Education.html">Education</a></li>
+							<li class="active"><a href="Education.html">Education</a></li>
 						</ul>
 						<ul class="icons">
 							<li><a href="https://www.linkedin.com/in/shinthantaung-alex/" class="icon brands fa-linkedin"><span class="label">LinkedIn</span></a></li>
 						</ul>
 					</nav>
-			</div>
 
-			<div id="main">
-				<section class="cards">
-					<div class="card">
-                        <img src="images/SP logo.jpeg" alt="" />
-						<h2>Singapore Polytechnic <br>(2023 - Current)</h2>
+				<!-- Main -->
+					<div id="main">
+						<section class="cards">
+							<div class="card">
+								<img src="images/SP logo.jpeg" alt="" />
+								<h2>Singapore Polytechnic <br>(2023 - Current)</h2>
+							</div>
+							<div class="card">
+								<img src="images/ielts logo.png" alt="" />
+								<h2>IELTS <br> (2022 - 2022)</h2>
+							</div>
+							<div class="card">
+								<img src="images/IGCSE.png" alt="" />
+								<h2>IGCSE 'O' Level<br> (2021 - 2022)</h2>
+							</div>
+						</section>
 					</div>
-					<div class="card">
-                        <img src="images/ielts logo.png" alt="" />
-						<h2>IELTS <br> (2022 - 2022)</h2>
-					</div>
-                    <div class="card">
-                        <img src="images/IGCSE.png" alt="" />
-						<h2>IGCSE 'O' Level<br> (2021 - 2022)</h2>
-					</div>
-				</section>
+
 			</div>
 
 		<!-- Scripts -->

--- a/work.html
+++ b/work.html
@@ -1,8 +1,7 @@
 <!DOCTYPE HTML>
-
 <html>
 	<head>
-		<title>Projects</title>
+		<title>Work Experience</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="assets/css/main.css" />
@@ -15,7 +14,7 @@
 
 				<!-- Header -->
 					<header id="header">
-						<a href="generic.html" class="logo">Experience</a>
+						<a href="work.html" class="logo">Experience</a>
 					</header>
 
 				<!-- Nav -->
@@ -30,16 +29,15 @@
 							<li><a href="https://www.linkedin.com/in/shinthantaung-alex/" class="icon brands fa-linkedin"><span class="label">LinkedIn</span></a></li>
 						</ul>
 					</nav>
-			</div>
 
-			<div id="main">
+				<!-- Main -->
+					<div id="main">
+						<h3>Work Experience</h3>
+						<p><span class="image left"><img src="images/mbs.jpg" alt="" /></span>From August 2023 to October 2023, I worked as a Food Server at Marina Bay Sands Rise Restaurant. My responsibilities included setting up and closing the restaurant, handling and assisting in food serving, and attending to customers by taking their orders. I ensured the maintenance of food hygiene and sanitation standards and carried out various tasks assigned by the Restaurant Manager. This role enhanced my communication, organizational, and multitasking skills, providing a solid foundation for my future endeavors in the hospitality industry.</p>
+						<p><span class="image right"><img src="images/nuss.jpg" alt="" /></span>From December 2023 to March 2024, I worked as a Food Server and Bartender at NUSS Café On The Ridge. I was responsible for daily operations, serving customers food and drinks, and removing and cleaning tables from used dishes. This role involved significant customer interaction, allowing me to enhance my communication, listening and interpersonal skills which are useful to have. Additionally, I developed drink crafting skills, which added a creative aspect to my work and contributed to a positive customer experience and work satisfaction.</p>
+						<hr />
+					</div>
 
-				<h3>Work Experience</h3>
-				<p><span class="image left"><img src="images/mbs.jpg" alt="" /></span>From August 2023 to October 2023, I worked as a Food Server at Marina Bay Sands Rise Restaurant. My responsibilities included setting up and closing the restaurant, handling and assisting in food serving, and attending to customers by taking their orders. I ensured the maintenance of food hygiene and sanitation standards and carried out various tasks assigned by the Restaurant Manager. This role enhanced my communication, organizational, and multitasking skills, providing a solid foundation for my future endeavors in the hospitality industry.</p>
-				<p><span class="image right"><img src="images/nuss.jpg" alt="" /></span>From December 2023 to March 2024, I worked as a Food Server and Bartender at NUSS Café On The Ridge. I was responsible for daily operations, serving customers food and drinks, and removing and cleaning tables from used dishes. This role involved significant customer interaction, allowing me to enhance my communication, listening and interpersonal skills which are usefull to have. Additionally, I developed drink crafting skills, which added a creative aspect to my work and contributed to a positive customer experience and work statisfication to my work life.</p>
-
-				<hr />
-					
 			</div>
 
 		<!-- Scripts -->


### PR DESCRIPTION
## Summary
- correct the Education page metadata and navigation so the header points to the right page and its content stays within the wrapper
- align the Work Experience page head metadata, navigation, and text while keeping the main content inside the wrapper

## Testing
- not run (static HTML site; no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_b_68d0f610b32083279bd7ff18b5360d96